### PR TITLE
feat: add flag for not running playground always

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"log"
 	"net/http"
@@ -28,9 +29,16 @@ func main() {
 		Reader: driver,
 	}}))
 
-	http.Handle("/", playground.Handler("GraphQL playground", "/query"))
+	runPlayground := flag.Bool("p", false, "Flag to activate playground")
+
+	flag.Parse()
+
 	http.Handle("/query", srv)
 
-	log.Printf("connect to http://localhost:%s/ for GraphQL playground", port)
+	if *runPlayground {
+		http.Handle("/", playground.Handler("GraphQL playground", "/query"))
+		log.Printf("connect to http://localhost:%s/ for GraphQL playground", port)
+	}
+
 	log.Fatal(http.ListenAndServe(":"+port, nil))
 }


### PR DESCRIPTION
Add -p flag for running and not running graphQL playground, it should just be used for testing.

Run with playground:
`CONNECTION_STRING="postgresql://postgres:password@localhost/postgres" go run server.go -p=true`

Run without playground:
`CONNECTION_STRING="postgresql://postgres:password@localhost/postgres" go run server.go`